### PR TITLE
Update HLSDownload.php (remove binary trim)

### DIFF
--- a/src/Ejz/HLSDownload.php
+++ b/src/Ejz/HLSDownload.php
@@ -161,7 +161,7 @@ class HLSDownload {
                         _warn("ERROR WHILE GETTING KEY: {$line}");
                         return false;
                     }
-                    $uri = bin2hex(trim($uri));
+                    $uri = bin2hex($uri);
                     $settings['key'] = array(
                         'method' => $method,
                         'uri' => $uri,


### PR DESCRIPTION
I just had a situation where bin2hex() was returning an incomplete hex key (missing two characters at the end), causing HLS decryption to fail. The trim() function was stripping a character that was needed.
```
bad decrypt
140673702995776:error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt:../crypto/evp/evp_enc.c:535:
ERROR WHILE DECRYPTING: Error while decoding!
```